### PR TITLE
Don't freeze responses

### DIFF
--- a/lib/regal/app.rb
+++ b/lib/regal/app.rb
@@ -354,9 +354,9 @@ module Regal
         end
         response
       elsif matching_route
-        METHOD_NOT_ALLOWED_RESPONSE
+        [405, {}, []]
       else
-        NOT_FOUND_RESPONSE
+        [404, {}, []]
       end
     end
 
@@ -373,8 +373,6 @@ module Regal
 
     private
 
-    METHOD_NOT_ALLOWED_RESPONSE = [405, {}.freeze, [].freeze].freeze
-    NOT_FOUND_RESPONSE = [404, {}.freeze, [].freeze].freeze
     SLASH = '/'.freeze
     PATH_INFO_KEY = 'PATH_INFO'.freeze
     REQUEST_METHOD_KEY = 'REQUEST_METHOD'.freeze


### PR DESCRIPTION
As it appears some Rack handlers will attempt to mutate them. This is a sample stacktrace I got when using Fishwife:

```
org.jruby.exceptions.RaiseException: (RuntimeError) can't modify frozen Hash
    at org.jruby.RubyHash.delete(org/jruby/RubyHash.java:1572) ~[my_app.jar:?]
    at RUBY.rack_to_servlet(/path/to/gems/fishwife-1.8.0-java/lib/fishwife/rack_servlet.rb:259) ~[?:?]
    at RUBY.service(/path/to/gems/fishwife-1.8.0-java/lib/fishwife/rack_servlet.rb:102) ~[?:?]
    at org.jruby.RubyKernel.catch(org/jruby/RubyKernel.java:1270) ~[my_app.jar:?]
    at RUBY.service(/path/to/gems/fishwife-1.8.0-java/lib/fishwife/rack_servlet.rb:96) ~[?:?]
```

While not obvious that they should be allowed mutate Regal's responses, I don't think it's obvious that they shouldn't either.
