### PR TITLE
Allow Regal to be installed with Rack 2.0

### DIFF
--- a/regal.gemspec
+++ b/regal.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'rack', '~> 1.5'
+  s.add_runtime_dependency 'rack', '>= 1.5'
 end


### PR DESCRIPTION
Just a minor change to the gemspec file to allow Regal to be used with Rack 2.0.