### PR TITLE
Don't split parameters on semicolons, only on ampersands

### DIFF
--- a/lib/regal/request.rb
+++ b/lib/regal/request.rb
@@ -19,7 +19,7 @@ module Regal
     # @return [Hash]
     def parameters
       @parameters ||= begin
-        query = Rack::Utils.parse_query(@env[QUERY_STRING_KEY])
+        query = Rack::Utils.parse_query(@env[QUERY_STRING_KEY], PARAMETER_SEPARATORS)
         query.merge!(@path_captures)
         query.freeze
       end
@@ -53,6 +53,7 @@ module Regal
 
     private
 
+    PARAMETER_SEPARATORS = '&'.freeze
     HEADER_PREFIX = 'HTTP_'.freeze
     QUERY_STRING_KEY = 'QUERY_STRING'.freeze
     CONTENT_LENGTH_KEY = 'CONTENT_LENGTH'.freeze

--- a/spec/regal/request_spec.rb
+++ b/spec/regal/request_spec.rb
@@ -36,6 +36,11 @@ module Regal
           expect { request.parameters[:new] = 'value' }.to raise_error(/can't modify frozen/)
         end
       end
+
+      it 'only considers "&" as a parameter separator' do
+        env['QUERY_STRING'] = 'a=1&b=2;c=3&d=4'
+        expect(request.parameters).to include('a' => '1', 'b' => '2;c=3', 'd' => '4')
+      end
     end
 
     describe '#headers' do


### PR DESCRIPTION
Rack's default query parser considers `;` to be equivalent to `&` in query strings – which is how things worked in 1999, but not anymore.

Assuming that the [application/x-www-form-urlencoded spec][1] applies to GET requests in general `;` is not a separator anymore ([but it was in 1999][2]). This is at least what I've been able to gather from [this StackOverflow][3] post.

  [1]: https://www.w3.org/TR/2014/REC-html5-20141028/forms.html#url-encoded-form-data
  [2]: https://www.w3.org/TR/1999/REC-html401-19991224/appendix/notes.html#h-B.2.2
  [3]: https://stackoverflow.com/a/40768572/1109