### PR TITLE
The parent of a Mounted app need to extract the default ("dynamic") route

### DIFF
--- a/lib/regal/app.rb
+++ b/lib/regal/app.rb
@@ -58,6 +58,7 @@ module Regal
           MountGraft.new(app, route)
         end
         routes.merge!(mounted_routes)
+        routes.default = mounted_routes.default
       end
       @routes.each do |path, cls|
         routes[path] = cls.new(attributes)

--- a/spec/regal/app_spec.rb
+++ b/spec/regal/app_spec.rb
@@ -730,6 +730,7 @@ module Regal
               'static'
             end
           end
+
           route :bar do
             get do
               'inside'
@@ -741,6 +742,7 @@ module Regal
           route 'foo' do
             mount InnerApp
           end
+
           route :outside do
             get do
               'outside'
@@ -749,7 +751,7 @@ module Regal
         end
       end
 
-      it 'prioritizes static the route' do
+      it 'prioritizes the static route' do
         get '/foo/static'
         expect(last_response.status).to eq(200)
         expect(last_response.body).to eq('static')
@@ -777,6 +779,7 @@ module Regal
             end
           end
         end
+
         InnerApp2 = App.create do
           route :bar do
             get do
@@ -793,7 +796,7 @@ module Regal
         end
       end
 
-      it 'gives priority to second capture route' do
+      it 'last capture route replaces earlier mounted capture route' do
         get '/foo/this'
         expect(last_response.status).to eq(200)
         expect(last_response.body).to eq('inside 2')

--- a/spec/regal/app_spec.rb
+++ b/spec/regal/app_spec.rb
@@ -592,6 +592,27 @@ module Regal
       end
     end
 
+    context 'an app that has a top-level capturing route' do
+      let :app do
+        App.new do
+          route :foo do
+            get do
+              'whatever'
+            end
+          end
+        end
+      end
+
+      it 'matches anything for the capture route' do
+        get '/something'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('whatever')
+        get '/something-else'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('whatever')
+      end
+    end
+
     context 'an app that mounts another app' do
       GoodbyeApp = App.create do
         route 'goodbye' do
@@ -698,6 +719,84 @@ module Regal
           expect(last_response.status).to eq(200)
           expect(last_response.body).to eq('simple2')
         end
+      end
+    end
+
+    context 'an app that has an mounted capturing route' do
+      let :app do
+        InnerApp = App.create do
+          route 'static' do
+            get do
+              'static'
+            end
+          end
+          route :bar do
+            get do
+              'inside'
+            end
+          end
+        end
+
+        App.new do
+          route 'foo' do
+            mount InnerApp
+          end
+          route :outside do
+            get do
+              'outside'
+            end
+          end
+        end
+      end
+
+      it 'prioritizes static the route' do
+        get '/foo/static'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('static')
+      end
+
+      it 'matches anything for the mounted capture route' do
+        get '/foo/this'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('inside')
+      end
+
+      it 'still matches anything for the parent capture route' do
+        get '/this'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('outside')
+      end
+    end
+
+    context 'an app that has two mounted capturing routes' do
+      let :app do
+        InnerApp1 = App.create do
+          route :bar do
+            get do
+              'inside 1'
+            end
+          end
+        end
+        InnerApp2 = App.create do
+          route :bar do
+            get do
+              'inside 2'
+            end
+          end
+        end
+
+        App.new do
+          route 'foo' do
+            mount InnerApp1
+            mount InnerApp2
+          end
+        end
+      end
+
+      it 'gives priority to second capture route' do
+        get '/foo/this'
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq('inside 2')
       end
     end
 


### PR DESCRIPTION
I tried to do 
```ruby
  Dimensions = Regal::App.create do
    route :account_id do
      route 'dimension' do
        get do |request|
          ...
        end
      end
    end
  end
...
  route 'v1' do
    mount Dimensions
  end
```
This did not work, because the inner app did not get its `#default` propagated properly by `#create_routes`. This PR addresses this.