### PR TITLE
Bump Rack dependency in gemspec

### DIFF
--- a/regal.gemspec
+++ b/regal.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'rack', '~> 1.5'
+  s.add_runtime_dependency 'rack', '~> 2.0'
 end


### PR DESCRIPTION
This enables use of Regal with more recent versions of Rack. The specs are passing and the update didn't break anything from what I can see.