### PR TITLE
Upgrade to Rack 3

### DIFF
--- a/lib/regal/app.rb
+++ b/lib/regal/app.rb
@@ -355,9 +355,9 @@ module Regal
         end
         response
       elsif matching_route
-        METHOD_NOT_ALLOWED_RESPONSE
+        [405, {}, []]
       else
-        NOT_FOUND_RESPONSE
+        [404, {}, []]
       end
     end
 
@@ -374,8 +374,6 @@ module Regal
 
     private
 
-    METHOD_NOT_ALLOWED_RESPONSE = [405, {}.freeze, [].freeze].freeze
-    NOT_FOUND_RESPONSE = [404, {}.freeze, [].freeze].freeze
     SLASH = '/'.freeze
     PATH_INFO_KEY = 'PATH_INFO'.freeze
     REQUEST_METHOD_KEY = 'REQUEST_METHOD'.freeze

--- a/lib/regal/response.rb
+++ b/lib/regal/response.rb
@@ -20,7 +20,7 @@ module Regal
     # @private
     def initialize
       @status = 200
-      @headers = {}
+      @headers = Rack::Headers.new
       @body = nil
       @raw_body = nil
       @finished = false

--- a/regal.gemspec
+++ b/regal.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'rack', '~> 2.0'
+  s.add_runtime_dependency 'rack', '~> 3.0'
 end

--- a/spec/regal/app_spec.rb
+++ b/spec/regal/app_spec.rb
@@ -126,7 +126,7 @@ module Regal
 
       it 'can set response headers' do
         get '/redirect'
-        expect(last_response.headers).to include('Location' => 'somewhere/else')
+        expect(last_response.headers).to include('location' => 'somewhere/else')
       end
     end
 
@@ -262,11 +262,11 @@ module Regal
 
         it 'does not call further handlers or before blocks when the response is marked as finished' do
           expect(last_response.body).to eq('Go somewhere else')
-          expect(last_response.headers).to_not have_key('X-HandlerCalled')
+          expect(last_response.headers).to_not have_key('x-handlercalled')
         end
 
         it 'calls after blocks' do
-          expect(last_response.headers).to include('WasAfterCalled' => 'yes')
+          expect(last_response.headers).to include('wasaftercalled' => 'yes')
         end
       end
 
@@ -882,28 +882,28 @@ module Regal
       it 'calls the route\'s parent scope\'s before blocks only' do
         get '/scoped/1'
         expect(last_response.status).to eq(200)
-        expect(last_response.headers).to include('BeforeScope' => '1')
+        expect(last_response.headers).to include('beforescope' => '1')
         get '/scoped/2'
         expect(last_response.status).to eq(200)
-        expect(last_response.headers).to include('BeforeScope' => '2', 'BeforeSubScope' => '2')
+        expect(last_response.headers).to include('beforescope' => '2', 'beforesubscope' => '2')
       end
 
       it 'calls the route\'s parent scope\'s after blocks only' do
         get '/scoped/1'
         expect(last_response.status).to eq(200)
-        expect(last_response.headers).to include('AfterScope' => '1')
+        expect(last_response.headers).to include('afterscope' => '1')
         get '/scoped/2'
         expect(last_response.status).to eq(200)
-        expect(last_response.headers).to include('AfterScope' => '2')
+        expect(last_response.headers).to include('afterscope' => '2')
       end
 
       it 'calls the common before and after blocks' do
         get '/scoped/1'
         expect(last_response.status).to eq(200)
-        expect(last_response.headers).to include('CommonBefore' => 'yes', 'CommonAfter' => 'yes')
+        expect(last_response.headers).to include('commonbefore' => 'yes', 'commonafter' => 'yes')
         get '/scoped/2'
         expect(last_response.status).to eq(200)
-        expect(last_response.headers).to include('CommonBefore' => 'yes', 'CommonAfter' => 'yes')
+        expect(last_response.headers).to include('commonbefore' => 'yes', 'commonafter' => 'yes')
       end
     end
 
@@ -1412,7 +1412,7 @@ module Regal
 
         it 'calls after blocks when errors are handled' do
           get '/handled'
-          expect(last_response.headers['WasAfterCalled']).to eq('yes')
+          expect(last_response.headers['wasaftercalled']).to eq('yes')
         end
 
         it 'lets them bubble all the way up when there are no matching error handlers' do
@@ -1428,12 +1428,12 @@ module Regal
 
         it 'delegates them to matching error handlers at the same level, not below' do
           get '/handled/at-the-right-level/level-3/level-4'
-          expect(last_response.headers).to include('HandledAtLevel' => '3')
+          expect(last_response.headers).to include('handledatlevel' => '3')
         end
 
         it 'calls after blocks when errors are handled' do
           get '/handled/from-before'
-          expect(last_response.headers['WasAfterCalled']).to eq('yes')
+          expect(last_response.headers['wasaftercalled']).to eq('yes')
         end
 
       end
@@ -1446,8 +1446,8 @@ module Regal
 
         it 'calls the rest of the after blocks when errors are handled' do
           get '/handled/from-after'
-          expect(last_response.headers['NextAfterWasCalled']).to eq('yes')
-          expect(last_response.headers['WasAfterCalled']).to eq('yes')
+          expect(last_response.headers['nextafterwascalled']).to eq('yes')
+          expect(last_response.headers['wasaftercalled']).to eq('yes')
         end
       end
 


### PR DESCRIPTION
Rack 2 is receiving security patches only, and effort should be made to move to Rack 3.

As far as I can tell only two things in the [upgrade guide](https://github.com/rack/rack/blob/main/UPGRADE-GUIDE.md) affect Regal directly:

1. Response headers must be a mutable hash

   The frozen responses for 404 and 405 have been inlined.

2. Response Headers must be lower case

   [Rack::Headers](https://rubydoc.info/gems/rack/Rack/Headers) is a `Hash` subclass that downcases all keys.
